### PR TITLE
Bringing back LibraryLogging and using Microsoft.Extensions.Logging.

### DIFF
--- a/Usenet/LibraryLogging.cs
+++ b/Usenet/LibraryLogging.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Usenet
+{
+    /// <summary>
+    /// Host for a singleton <see cref="ILoggerFactory"/>
+    /// (<a href="https://stackify.com/net-core-loggerfactory-use-correctly/">Source</a>).
+    /// </summary>
+    public static class LibraryLogging
+    {
+        private static ILoggerFactory factoryInstance;
+
+        /// <summary>
+        /// The singleton <see cref="ILoggerFactory"/> to use throughout the entire library.
+        /// </summary>
+        public static ILoggerFactory Factory
+        {
+            get => factoryInstance ?? (factoryInstance = new LoggerFactory());
+            set => factoryInstance = value;
+        }
+
+        /// <summary>
+        /// Uses the <see cref="ILoggerFactory"/> to create a logger for the given type.
+        /// </summary>
+        /// <typeparam name="T">The type to create the logger for.</typeparam>
+        /// <returns>A logger for the given type.</returns>
+        public static ILogger Create<T>() => Factory.CreateLogger<T>();
+    }
+}

--- a/Usenet/Nntp/Builders/NntpArticleBuilder.cs
+++ b/Usenet/Nntp/Builders/NntpArticleBuilder.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 using System.Linq;
 using Usenet.Exceptions;
 using Usenet.Extensions;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Models;
 using Usenet.Util;
 
@@ -16,7 +16,7 @@ namespace Usenet.Nntp.Builders
     /// </summary>
     public class NntpArticleBuilder
     {
-        private static readonly ILog log = LogProvider.For<NntpArticleBuilder>();
+        private static readonly ILogger log = LibraryLogging.Create<NntpArticleBuilder>();
 
         private const string dateFormat = "dd MMM yyyy HH:mm:ss";
 
@@ -78,7 +78,7 @@ namespace Usenet.Nntp.Builders
                             }
                             else
                             {
-                                log.Warn("Found more than 1 {messageId} header. Skipping it.", NntpHeaders.MessageId);
+                                log.LogWarning("Found more than 1 {messageId} header. Skipping it.", NntpHeaders.MessageId);
                             }
                             break;
 
@@ -89,7 +89,7 @@ namespace Usenet.Nntp.Builders
                             }
                             else
                             {
-                                log.Warn("Found more than 1 {from} header. Skipping it.", NntpHeaders.From);
+                                log.LogWarning("Found more than 1 {from} header. Skipping it.", NntpHeaders.From);
                             }
                             break;
 
@@ -100,7 +100,7 @@ namespace Usenet.Nntp.Builders
                             }
                             else
                             {
-                                log.Warn("Found more than 1 {subject} header. Skipping it.", NntpHeaders.Subject);
+                                log.LogWarning("Found more than 1 {subject} header. Skipping it.", NntpHeaders.Subject);
                             }
                             break;
 
@@ -115,12 +115,12 @@ namespace Usenet.Nntp.Builders
                                 }
                                 else
                                 {
-                                    log.Warn("{date} header has invalid value {value}. Skipping it.", NntpHeaders.Date, value);
+                                    log.LogWarning("{date} header has invalid value {value}. Skipping it.", NntpHeaders.Date, value);
                                 }
                             }
                             else
                             {
-                                log.Warn("Found more than 1 {date} header. Skipping it.", NntpHeaders.Date);
+                                log.LogWarning("Found more than 1 {date} header. Skipping it.", NntpHeaders.Date);
                             }
                             break;
 

--- a/Usenet/Nntp/NntpConnection.cs
+++ b/Usenet/Nntp/NntpConnection.cs
@@ -5,7 +5,7 @@ using System.Net.Security;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Usenet.Exceptions;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Parsers;
 using Usenet.Nntp.Responses;
 using Usenet.Util;
@@ -20,7 +20,7 @@ namespace Usenet.Nntp
     /// does not support compressed multi-line results.</remarks>
     public class NntpConnection : INntpConnection
     {
-        private static readonly ILog log = LogProvider.For<NntpConnection>();
+        private static readonly ILogger log = LibraryLogging.Create<NntpConnection>();
 
         private readonly TcpClient client = new TcpClient();
         private StreamWriter writer;
@@ -32,7 +32,7 @@ namespace Usenet.Nntp
         /// <inheritdoc/>
         public async Task<TResponse> ConnectAsync<TResponse>(string hostname, int port, bool useSsl, IResponseParser<TResponse> parser)
         {
-            log.Info("Connecting: {hostname} {port} (Use SSl = {useSsl})", hostname, port, useSsl);
+            log.LogInformation("Connecting: {hostname} {port} (Use SSl = {useSsl})", hostname, port, useSsl);
             await client.ConnectAsync(hostname, port);
             Stream = await GetStreamAsync(hostname, useSsl);
             writer = new StreamWriter(Stream, UsenetEncoding.Default) { AutoFlush = true };
@@ -44,7 +44,7 @@ namespace Usenet.Nntp
         public TResponse Command<TResponse>(string command, IResponseParser<TResponse> parser)
         {
             ThrowIfNotConnected();
-            log.Info("Sending command: {Command}",command.StartsWith("AUTHINFO PASS", StringComparison.Ordinal) ? "AUTHINFO PASS [omitted]" : command);
+            log.LogInformation("Sending command: {Command}",command.StartsWith("AUTHINFO PASS", StringComparison.Ordinal) ? "AUTHINFO PASS [omitted]" : command);
             writer.WriteLine(command);
             return GetResponse(parser);
         }
@@ -65,7 +65,7 @@ namespace Usenet.Nntp
         public TResponse GetResponse<TResponse>(IResponseParser<TResponse> parser)
         {
             string responseText = reader.ReadLine();
-            log.Info("Response received: {Response}", responseText);
+            log.LogInformation("Response received: {Response}", responseText);
 
             if (responseText == null)
             {

--- a/Usenet/Nntp/Parsers/ArticleResponseParser.cs
+++ b/Usenet/Nntp/Parsers/ArticleResponseParser.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Builders;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
@@ -19,7 +19,7 @@ namespace Usenet.Nntp.Parsers
 
     internal class ArticleResponseParser : IMultiLineResponseParser<NntpArticleResponse>
     {
-        private static readonly ILog log = LogProvider.For<ArticleResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<ArticleResponseParser>();
 
         private readonly ArticleRequestType requestType;
         private readonly int successCode;
@@ -58,7 +58,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 2)
             {
-                log.Error("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
+                log.LogError("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long number);
@@ -121,7 +121,7 @@ namespace Usenet.Nntp.Parsers
                     int splitPos = line.IndexOf(':');
                     if (splitPos < 0)
                     {
-                        log.Error("Invalid header line: {Line} Expected: {{key}}:{{value}}", line);
+                        log.LogError("Invalid header line: {Line} Expected: {{key}}:{{value}}", line);
                     }
                     else
                     {

--- a/Usenet/Nntp/Parsers/DateResponseParser.cs
+++ b/Usenet/Nntp/Parsers/DateResponseParser.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Globalization;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Responses;
 
 namespace Usenet.Nntp.Parsers
 {
     internal class DateResponseParser : IResponseParser<NntpDateResponse>
     {
-        private static readonly ILog log = LogProvider.For<DateResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<DateResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == 111;
 
@@ -21,7 +21,7 @@ namespace Usenet.Nntp.Parsers
                 return new NntpDateResponse(code, message, true, dateTime);
             }
             
-            log.Error("Invalid response message: {Message} Expected: {{yyyymmddhhmmss}}", message);
+            log.LogError("Invalid response message: {Message} Expected: {{yyyymmddhhmmss}}", message);
             return new NntpDateResponse(code, message, false, DateTimeOffset.MinValue);
         }
     }

--- a/Usenet/Nntp/Parsers/GroupOriginsResponseParser.cs
+++ b/Usenet/Nntp/Parsers/GroupOriginsResponseParser.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
 
@@ -9,7 +9,7 @@ namespace Usenet.Nntp.Parsers
 {
     internal class GroupOriginsResponseParser : IMultiLineResponseParser<NntpGroupOriginsResponse>
     {
-        private static readonly ILog log = LogProvider.For<GroupOriginsResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<GroupOriginsResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == 215;
 
@@ -43,7 +43,7 @@ namespace Usenet.Nntp.Parsers
                 string[] lineSplit = line.Split(' ');
                 if (lineSplit.Length < 3)
                 {
-                    log.Error("Invalid newsgroup origin line: {Line} Expected: {{group}} {{timestamp}} {{createdby}}", line);
+                    log.LogError("Invalid newsgroup origin line: {Line} Expected: {{group}} {{timestamp}} {{createdby}}", line);
                     continue;
                 }
 

--- a/Usenet/Nntp/Parsers/GroupResponseParser.cs
+++ b/Usenet/Nntp/Parsers/GroupResponseParser.cs
@@ -1,4 +1,4 @@
-﻿using Usenet.Logging;
+﻿using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
 
@@ -6,7 +6,7 @@ namespace Usenet.Nntp.Parsers
 {
     internal class GroupResponseParser : IResponseParser<NntpGroupResponse>
     {
-        private static readonly ILog log = LogProvider.For<GroupResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<GroupResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == 211;
 
@@ -22,7 +22,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 4)
             {
-                log.Error("Invalid response message: {Message} Expected: {{count}} {{low}} {{high}} {{group}}", message);
+                log.LogError("Invalid response message: {Message} Expected: {{count}} {{low}} {{high}} {{group}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long articleCount);

--- a/Usenet/Nntp/Parsers/GroupsResponseParser.cs
+++ b/Usenet/Nntp/Parsers/GroupsResponseParser.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
 
@@ -16,7 +16,7 @@ namespace Usenet.Nntp.Parsers
     {
         private readonly int successCode;
         private readonly GroupStatusRequestType requestType;
-        private static readonly ILog log = LogProvider.For<GroupsResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<GroupsResponseParser>();
 
         public GroupsResponseParser(int successCode, GroupStatusRequestType requestType)
         {
@@ -61,7 +61,7 @@ namespace Usenet.Nntp.Parsers
                 string[] lineSplit = line.Split(' ');
                 if (lineSplit.Length < checkParameterCount)
                 {
-                    log.Error(errorMessage, line);
+                    log.LogError(errorMessage, line);
                     continue;
                 }
 
@@ -78,7 +78,7 @@ namespace Usenet.Nntp.Parsers
                 NntpPostingStatus postingStatus = PostingStatusParser.Parse(lineSplit[argCount], out string otherGroup);
                 if (postingStatus == NntpPostingStatus.Unknown)
                 {
-                    log.Error("Invalid posting status {Status} in line: {Line}", lineSplit[argCount], line);
+                    log.LogError("Invalid posting status {Status} in line: {Line}", lineSplit[argCount], line);
                 }
 
                 yield return new NntpGroup(

--- a/Usenet/Nntp/Parsers/LastResponseParser.cs
+++ b/Usenet/Nntp/Parsers/LastResponseParser.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Responses;
 
 namespace Usenet.Nntp.Parsers
 {
     internal class LastResponseParser : IResponseParser<NntpLastResponse>
     {
-        private static readonly ILog log = LogProvider.For<LastResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<LastResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == (int) NntpLastResponseType.ArticleExists;
 
@@ -18,7 +18,7 @@ namespace Usenet.Nntp.Parsers
 
             if (responseType == NntpLastResponseType.Unknown)
             {
-                log.Error("Invalid response code: {Code}", code);
+                log.LogError("Invalid response code: {Code}", code);
             }
 
             if (!IsSuccessResponse(code))
@@ -30,7 +30,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 2)
             {
-                log.Error("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
+                log.LogError("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long number);

--- a/Usenet/Nntp/Parsers/ListGroupResponseParser.cs
+++ b/Usenet/Nntp/Parsers/ListGroupResponseParser.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Models;
 using Usenet.Nntp.Responses;
 
@@ -8,7 +8,7 @@ namespace Usenet.Nntp.Parsers
 {
     internal class ListGroupResponseParser : IMultiLineResponseParser<NntpGroupResponse>
     {
-        private static readonly ILog log = LogProvider.For<ListGroupResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<ListGroupResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == 211;
 
@@ -25,7 +25,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 4)
             {
-                log.Warn("Invalid response message: {Message} Expected: {{count}} {{low}} {{high}} {{group}}", message);
+                log.LogWarning("Invalid response message: {Message} Expected: {{count}} {{low}} {{high}} {{group}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long articleCount);

--- a/Usenet/Nntp/Parsers/ModeReaderResponseParser.cs
+++ b/Usenet/Nntp/Parsers/ModeReaderResponseParser.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Responses;
 
 namespace Usenet.Nntp.Parsers
 {
     internal class ModeReaderResponseParser : IResponseParser<NntpModeReaderResponse>
     {
-        private static readonly ILog log = LogProvider.For<ModeReaderResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<ModeReaderResponseParser>();
 
         public bool IsSuccessResponse(int code) => GetResponseType(code) != NntpModeReaderResponseType.Unknown;
 
@@ -16,7 +16,7 @@ namespace Usenet.Nntp.Parsers
             bool success = responseType != NntpModeReaderResponseType.Unknown;
             if (!success)
             {
-                log.Error("Invalid response code: {Code}", code);
+                log.LogError("Invalid response code: {Code}", code);
             }
             return new NntpModeReaderResponse(code, message, success, responseType);
         }

--- a/Usenet/Nntp/Parsers/NextResponseParser.cs
+++ b/Usenet/Nntp/Parsers/NextResponseParser.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Responses;
 
 namespace Usenet.Nntp.Parsers
 {
     internal class NextResponseParser : IResponseParser<NntpNextResponse>
     {
-        private static readonly ILog log = LogProvider.For<NextResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<NextResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == (int) NntpNextResponseType.ArticleExists;
 
@@ -18,7 +18,7 @@ namespace Usenet.Nntp.Parsers
 
             if (responseType == NntpNextResponseType.Unknown)
             {
-                log.Error("Invalid response code: {Code}", code);
+                log.LogError("Invalid response code: {Code}", code);
             }
 
             if (!IsSuccessResponse(code))
@@ -30,7 +30,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 2)
             {
-                log.Error("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
+                log.LogError("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long number);

--- a/Usenet/Nntp/Parsers/StatResponseParser.cs
+++ b/Usenet/Nntp/Parsers/StatResponseParser.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using Usenet.Logging;
+using Microsoft.Extensions.Logging;
 using Usenet.Nntp.Responses;
 
 namespace Usenet.Nntp.Parsers
 {
     internal class StatResponseParser : IResponseParser<NntpStatResponse>
     {
-        private static readonly ILog log = LogProvider.For<StatResponseParser>();
+        private static readonly ILogger log = LibraryLogging.Create<StatResponseParser>();
 
         public bool IsSuccessResponse(int code) => code == (int) NntpStatResponseType.ArticleExists;
 
@@ -18,7 +18,7 @@ namespace Usenet.Nntp.Parsers
 
             if (responseType == NntpStatResponseType.Unknown)
             {
-                log.Error("Invalid response code: {Code}", code);
+                log.LogError("Invalid response code: {Code}", code);
             }
 
             if (!IsSuccessResponse(code))
@@ -30,7 +30,7 @@ namespace Usenet.Nntp.Parsers
             string[] responseSplit = message.Split(' ');
             if (responseSplit.Length < 2)
             {
-                log.Error("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
+                log.LogError("Invalid response message: {Message} Expected: {{number}} {{messageid}}", message);
             }
 
             long.TryParse(responseSplit.Length > 0 ? responseSplit[0] : null, out long number);

--- a/Usenet/Usenet.csproj
+++ b/Usenet/Usenet.csproj
@@ -18,12 +18,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="LibLog" Version="5.0.6">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Abstractions" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.5" />
     <PackageReference Include="System.Collections.Immutable" Version="1.6.0" />
     <PackageReference Include="System.Net.Security" Version="4.3.2" />
   </ItemGroup>


### PR DESCRIPTION
Per https://github.com/keimpema/Usenet/issues/13, LibLog has been deprecated, this PR goes back to use of Microsoft.Extensions.Logging.