### PR TITLE
Simplify header date time string parsing by using a regular expression

### DIFF
--- a/Usenet/Nntp/Parsers/HeaderDateParser.cs
+++ b/Usenet/Nntp/Parsers/HeaderDateParser.cs
@@ -6,7 +6,17 @@ namespace Usenet.Nntp.Parsers
 {
     internal static class HeaderDateParser
     {
-        private static Regex _dateTimeRegx = new Regex(@"(?:\s*(?<dayName>Sun|Mon|Tue|Wed|Thu|Fri|Sat),)?\s*(?<day>\d{1,2})\s+(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+(?<year>\d{2,4})\s+(?<hour>\d{1,2}):(?<min>\d{1,2})(?::(?<sec>\d{1,2}))?\s*(?<tz>[+-]\d+|(?:UT|UTC|GMT|Z|EDT|EST|CDT|CST|MDT|MST|PDT|PST|A|N|M|Y|[A-Z]+))?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private const string _dateTimeRegexString =
+              @"(?:\s*"
+            + @"(?<dayName>Sun|Mon|Tue|Wed|Thu|Fri|Sat),)?\s*"
+            + @"(?<day>\d{1,2})\s+"
+            + @"(?<month>Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+"
+            + @"(?<year>\d{2,4})\s+"
+            + @"(?<hour>\d{1,2}):(?<min>\d{1,2})(?::(?<sec>\d{1,2}))?\s*"
+            + @"(?<tz>[+-]\d+|(?:UT|UTC|GMT|Z|EDT|EST|CDT|CST|MDT|MST|PDT|PST|A|N|M|Y|[A-Z]+)"
+            + @")?";
+
+        private static readonly Regex _dateTimeRegex = new Regex(_dateTimeRegexString, RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// Parses header date/time strings as described in the
@@ -21,10 +31,10 @@ namespace Usenet.Nntp.Parsers
                 return null;
             }
 
-            var matches = _dateTimeRegx.Match(value);
+            var matches = _dateTimeRegex.Match(value);
             if (!matches.Success)
             {
-                throw new FormatException(/*Resources.Nntp.BadHeaderDateFormat*/);
+                throw new FormatException(Resources.Nntp.BadHeaderDateFormat);
             }
 
             var day = int.Parse(matches.Groups["day"].Value);
@@ -64,7 +74,7 @@ namespace Usenet.Nntp.Parsers
             {
                 switch (value)
                 {
-                    // UTC is not specified in RFC822, but allowing it since it is commonly used
+                    // UTC and empty are not specified in RFC822, but allowing them since they are commonly used
                     case "UTC":
                     case "UT":
                     case "GMT":

--- a/UsenetTests/Nntp/Parsers/HeaderDateParserTests.cs
+++ b/UsenetTests/Nntp/Parsers/HeaderDateParserTests.cs
@@ -10,6 +10,10 @@ namespace UsenetTests.Nntp.Parsers
     {
         public static readonly IEnumerable<object[]> ParseData = new[]
         {
+            new object[] {"Mon, 1 May 2017 1:55", new DateTimeOffset(2017, 5, 1, 1, 55, 0, TimeSpan.Zero)},
+            new object[] {"1 May 2017 1:55:33", new DateTimeOffset(2017, 5, 1, 1, 55, 33, TimeSpan.Zero)},
+            new object[] {"01 May 2017 13:55", new DateTimeOffset(2017, 5, 1, 13, 55, 0, TimeSpan.Zero)},
+            new object[] {"01 May 2017 13:55:33", new DateTimeOffset(2017, 5, 1, 13, 55, 33, TimeSpan.Zero)},
             new object[] {"01 May 2017 13:55:33 +0000", new DateTimeOffset(2017, 5, 1, 13, 55, 33, TimeSpan.Zero)},
             new object[] {"01 May 2017 13:55:33 -0000", new DateTimeOffset(2017, 5, 1, 13, 55, 33, TimeSpan.Zero)},
             new object[] {"01 May 2017 13:55:33 +0000 (UTC)", new DateTimeOffset(2017, 5, 1, 13, 55, 33, TimeSpan.Zero)},
@@ -19,6 +23,9 @@ namespace UsenetTests.Nntp.Parsers
 
             new object[] {"01 May 2017 13:55 +1030", new DateTimeOffset(2017, 5, 1, 13, 55, 0, TimeSpan.FromMinutes(10 * 60 + 30))},
             new object[] {"01 May 2017 13:55 -1030", new DateTimeOffset(2017, 5, 1, 13, 55, 0, -TimeSpan.FromMinutes(10 * 60 + 30))},
+
+            new object[] {"01 May 2017 13:55+1030", new DateTimeOffset(2017, 5, 1, 13, 55, 0, TimeSpan.FromMinutes(10 * 60 + 30))},
+            new object[] {"01 May 2017 13:55-1030", new DateTimeOffset(2017, 5, 1, 13, 55, 0, -TimeSpan.FromMinutes(10 * 60 + 30))},
 
             new object[] {"1 Jan 2017 00:00:00 +0000", new DateTimeOffset(2017, 1, 1, 0, 0, 0, TimeSpan.Zero)},
             new object[] {"1 Feb 2017 00:00:00 +0000", new DateTimeOffset(2017, 2, 1, 0, 0, 0, TimeSpan.Zero)},
@@ -75,7 +82,7 @@ namespace UsenetTests.Nntp.Parsers
 
         [Theory]
         [MemberData(nameof(TimezoneParseFailureData))]
-        public void HeaderDateShouldBeNotBeParsedCorrectly(string headerDate, Type exceptionType)
+        public void HeaderDateShouldNotBeParsedCorrectly(string headerDate, Type exceptionType)
         {
             Assert.Throws(exceptionType, () => HeaderDateParser.Parse(headerDate));
         }


### PR DESCRIPTION
On a news server I user, I ran into some more odd-ball formats for header date time fields. So, I rewrote the parsing logic to use a regular expression rather than all the special-case logic that was there. All related tests succeed.