### PR TITLE
Allow ignoring RemoteCertificateNameMismatch

### DIFF
--- a/Usenet/Nntp/CustomCertValidator.cs
+++ b/Usenet/Nntp/CustomCertValidator.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Usenet.Nntp
+{
+    public static class CustomCertValidator
+    {
+        private static readonly HashSet<string> IgnoredHosts =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        private static bool _ignoreAllNameMismatch = false;
+
+        // --------------------------------------------------------
+        // Static constructor: reads environment variables once
+        // --------------------------------------------------------
+        static CustomCertValidator()
+        {
+            // Global ignore flag
+            var ignoreAll = Environment.GetEnvironmentVariable("NZBDAV_NNTP_TLS_IGNORE_NAME_MISMATCH");
+            if (!string.IsNullOrEmpty(ignoreAll) &&
+                ignoreAll.Equals("true", StringComparison.OrdinalIgnoreCase))
+            {
+                EnableGlobalIgnore();
+            }
+
+            // Per-host ignore list
+            var hosts = Environment.GetEnvironmentVariable("NZBDAV_NNTP_TLS_IGNORE_HOSTS");
+            if (!string.IsNullOrWhiteSpace(hosts))
+            {
+                foreach (var host in hosts.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    AddIgnoredHost(host.Trim());
+                }
+            }
+        }
+
+        /// <summary>
+        /// Globally ignore RemoteCertificateNameMismatch for all hosts.
+        /// </summary>
+        public static void EnableGlobalIgnore()
+        {
+            _ignoreAllNameMismatch = true;
+        }
+
+        /// <summary>
+        /// Ignore certificate name mismatch for a specific hostname.
+        /// </summary>
+        public static void AddIgnoredHost(string host)
+        {
+            if (!string.IsNullOrWhiteSpace(host))
+                IgnoredHosts.Add(host);
+        }
+
+        /// <summary>
+        /// Validate the server certificate, applying global and per-host overrides.
+        /// </summary>
+        public static bool Validate(
+            object sender,
+            X509Certificate certificate,
+            X509Chain chain,
+            SslPolicyErrors sslErrors,
+            string targetHost)
+        {
+            // Allow all mismatched certs globally
+            if (_ignoreAllNameMismatch &&
+                sslErrors == SslPolicyErrors.RemoteCertificateNameMismatch)
+                return true;
+
+            // Allow mismatched certs for specific hosts
+            if (IgnoredHosts.Contains(targetHost) &&
+                sslErrors == SslPolicyErrors.RemoteCertificateNameMismatch)
+                return true;
+
+            // Allow only completely clean certificates otherwise
+            return sslErrors == SslPolicyErrors.None;
+        }
+    }
+}

--- a/Usenet/Usenet.csproj
+++ b/Usenet/Usenet.csproj
@@ -4,25 +4,22 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Usenet</RootNamespace>
     <AssemblyName>Usenet</AssemblyName>
-    <Authors>Harmen van Keimpema</Authors>
+    <Authors>Harmen van Keimpema, pannal</Authors>
     <Company />
     <Description>A library for working with Usenet. It offers an NNTP client, an NZB file parser, builder, writer, a yEnc encoder and decoder. It is mainly focused on keeping memory usage low. Server responses can be enumerated as they come in. Binary messages will be encoded to yEnc format streaming and yEnc-encoded data will be decoded to binary data streaming.</Description>
     <PackageProjectUrl>https://github.com/keimpema/Usenet</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/keimpema/Usenet</RepositoryUrl>
+    <RepositoryUrl>https://github.com/pannal/Usenet</RepositoryUrl>
     <RepositoryType />
     <PackageTags>usenet;nntp;nzb;yenc</PackageTags>
-    <PackageId>Usenet</PackageId>
+    <PackageId>Usenet.Custom</PackageId>
     <Product>Usenet</Product>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <Version>3.1.1-nzbdav</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitVersion.MsBuild" Version="5.6.10">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Adds handling of the environment variables:
NZBDAV_NNTP_TLS_IGNORE_NAME_MISMATCH[=true]
NZBDAV_NNTP_TLS_IGNORE_HOSTS[=host1[,;]host2]